### PR TITLE
VibeVoice: real-weight bias layout fixes (linear_no_bias + weight-less FinalLayer)

### DIFF
--- a/candle-transformers/src/models/vibevoice/diffusion_head.rs
+++ b/candle-transformers/src/models/vibevoice/diffusion_head.rs
@@ -22,7 +22,7 @@
 //! formula `eps = eps_uncond + scale * (eps_cond - eps_uncond)`.
 
 use candle::{DType, Device, Result, Tensor, D};
-use candle_nn::{linear, Linear, Module, VarBuilder};
+use candle_nn::{linear_no_bias as linear, Linear, Module, VarBuilder};
 
 use super::config::VibeVoiceDiffusionHeadConfig;
 

--- a/candle-transformers/src/models/vibevoice/diffusion_head.rs
+++ b/candle-transformers/src/models/vibevoice/diffusion_head.rs
@@ -202,20 +202,26 @@ impl HeadLayer {
 /// Final layer that produces the noise/velocity prediction. Same AdaLN
 /// modulation pattern but only `(shift, scale)` — no FFN, just a direct
 /// linear projection from `hidden_size` to `latent_size`.
+///
+/// Note: VibeVoice's released `FinalLayer` ships a *weight-less*
+/// pre-norm (Python's `RMSNorm(..., elementwise_affine=False)`); only
+/// the `adaLN_modulation.1.weight` and `linear.weight` tensors appear
+/// under `model.prediction_head.final_layer.*` in the index. We mirror
+/// that by storing `rms_eps` and applying `rsqrt(mean(x², -1) + eps)`
+/// inline in `forward`, with no `RmsNorm::weight` to load.
 #[derive(Debug, Clone)]
 struct FinalLayer {
-    norm: RmsNorm,
+    rms_eps: f64,
     cond_proj: Linear,
     out_proj: Linear,
 }
 
 impl FinalLayer {
     fn new(hidden_size: usize, latent_size: usize, rms_eps: f64, vb: VarBuilder) -> Result<Self> {
-        let norm = RmsNorm::new(hidden_size, rms_eps, vb.pp("norm"))?;
         let cond_proj = linear(hidden_size, 2 * hidden_size, vb.pp("adaLN_modulation.1"))?;
         let out_proj = linear(hidden_size, latent_size, vb.pp("linear"))?;
         Ok(Self {
-            norm,
+            rms_eps,
             cond_proj,
             out_proj,
         })
@@ -227,7 +233,14 @@ impl FinalLayer {
         let chunks = proj.chunk(2, D::Minus1)?;
         let (shift, scale) = (&chunks[0], &chunks[1]);
 
-        let normalized = self.norm.forward(x)?;
+        // Weight-less RMSNorm: x * rsqrt(mean(x², dim=-1) + eps).
+        // Computed in f32 for numerical stability and cast back.
+        let in_dtype = x.dtype();
+        let xf = x.to_dtype(DType::F32)?;
+        let variance = xf.sqr()?.mean_keepdim(D::Minus1)?;
+        let inv_rms = (variance + self.rms_eps)?.sqrt()?.recip()?;
+        let normalized = xf.broadcast_mul(&inv_rms)?.to_dtype(in_dtype)?;
+
         let modulated = modulate(&normalized, shift, scale)?;
         self.out_proj.forward(&modulated)
     }

--- a/candle-transformers/src/models/vibevoice/inference.rs
+++ b/candle-transformers/src/models/vibevoice/inference.rs
@@ -146,6 +146,22 @@ pub fn generate_audio(
         // for the diffusion head. Shape: (1, hidden).
         let last_hidden = hidden.narrow(1, hidden.dim(1)? - 1, 1)?.squeeze(1)?;
 
+        // Debug helper: opt-in via `VIBEVOICE_DEBUG_GENERATE=1`. Prints
+        // mean/std of next_input + last_hidden + the eventual latent at
+        // each step so a failing autoregressive loop ("stuck on one
+        // token") is easy to diagnose.
+        let debug_loop = std::env::var("VIBEVOICE_DEBUG_GENERATE")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        if debug_loop && step_idx < 8 {
+            let ni_stats = tensor_mean_std(&next_input)?;
+            let lh_stats = tensor_mean_std(&last_hidden)?;
+            eprintln!(
+                "[vv.gen step={step_idx} offset={seqlen_offset}]  next_input μ={:+.4} σ={:.4}  last_hidden μ={:+.4} σ={:.4}",
+                ni_stats.0, ni_stats.1, lh_stats.0, lh_stats.1,
+            );
+        }
+
         // 3c — EOS check (vocab-token mode). Upstream's streaming variant
         // uses a binary classifier here; the spec opts for a configurable
         // token id via the lm_head. If both are wired we honour the
@@ -177,6 +193,14 @@ pub fn generate_audio(
             &device,
             dtype,
         )?;
+
+        if debug_loop && step_idx < 8 {
+            let lat_stats = tensor_mean_std(&latent)?;
+            eprintln!(
+                "[vv.gen step={step_idx}]  latent (pre-scale) μ={:+.4} σ={:.4}",
+                lat_stats.0, lat_stats.1,
+            );
+        }
 
         // 3e — invert the training-time scaling so the latent lives in
         // the acoustic decoder's expected range (model.py L326 inverse,
@@ -302,6 +326,17 @@ fn invert_scaling(latent: &Tensor, model: &VibeVoiceModel) -> Result<Tensor> {
     let bias = model.speech_bias_factor();
     let scaled = latent.broadcast_div(scaling)?;
     scaled.broadcast_sub(bias)
+}
+
+/// Cheap (mean, std) summary used by the optional debug logging. Both
+/// reductions go through f32 to avoid bf16 precision artifacts.
+fn tensor_mean_std(t: &Tensor) -> Result<(f32, f32)> {
+    let f = t.to_dtype(DType::F32)?.flatten_all()?;
+    let n = f.dim(0)? as f32;
+    let mean = f.sum(0)?.to_scalar::<f32>()? / n;
+    let centered = (f - mean as f64)?;
+    let var = (centered.sqr()?.sum(0)?.to_scalar::<f32>()?) / n;
+    Ok((mean, var.sqrt()))
 }
 
 /// Compute the per-call diffusion-step budget. Caller can pass an


### PR DESCRIPTION
## Summary

Three commits caught by **real-weight validation** — running candle's VibeVoice port against an actual `microsoft/VibeVoice-1.5B` checkpoint surfaced bugs that synthetic-init shape tests can't catch:

1. **`f34118cf`** — Diffusion head linears: switched all 10 `linear()` to `linear_no_bias()`. Released checkpoint stores all 26 prediction_head modules as weight-only (verified against `model.safetensors.index.json`). Without this, model construction fails with `cannot find tensor model.prediction_head.noisy_images_proj.bias`.
2. **`0a48d3ff`** — `FinalLayer` pre-norm is weight-less (`RMSNorm(elementwise_affine=False)`). Released checkpoint has no `model.prediction_head.final_layer.norm.weight` — only `adaLN_modulation.1.weight` and `linear.weight`. Replaced the `RmsNorm` field with inline `rsqrt(mean(x², -1) + eps)` in `forward()`.
3. **`5a61614a`** — Opt-in debug logging in `generate_audio` loop. Set `VIBEVOICE_DEBUG_GENERATE=1` to print per-step mean/std of LM input embedding, last hidden state, and pre-scale diffusion latent. Used to diagnose stuck-on-one-token failures.

## Verification

Without these fixes, HybrIE's `real_weight_synthesize_writes_wav` test panics at model construction with missing-key errors. With these fixes, it loads cleanly, runs the full diffusion + decoder, and produces a 24 kHz WAV. After also adding the proper VibeVoice prompt template on the consumer side (HybrIE), the audio Whisper-transcribes as recognizable English speech.

## Tests

- 21 vibevoice-port lib tests pass (no change)
- `cargo clippy --no-default-features --lib -- -D warnings` clean
- `rustfmt --check` clean

## Compatibility

- Public API unchanged. The only behavior change is which keys the loader looks for in safetensors.
- No-op for callers using synthetic-init (VarMap auto-creates whatever keys are queried).

## Out of scope

- Voice-sample conditioning (text faithfulness still relies on speaker reference; without it, synthesized speech drifts off-prompt)
- Imperceptible audio-domain watermark
- Streaming-inference variant