### PR TITLE
openai-privacy-filter: example binary

### DIFF
--- a/candle-examples/examples/openai-privacy-filter/README.md
+++ b/candle-examples/examples/openai-privacy-filter/README.md
@@ -1,0 +1,49 @@
+# OpenAI privacy-filter / OpenMed privacy-filter-nemotron
+
+PII detection via the `openai_privacy_filter` token classifier:
+
+- 1.4B parameter sparse-MoE (8 layers × 128 experts × top-4)
+- 50M active parameters per token
+- 221 BIOES labels over 55 PII categories
+- Constrained Viterbi decoding by default
+
+## Run
+
+```bash
+# Default model: OpenMed/privacy-filter-nemotron (Apache 2.0)
+cargo run --example openai-privacy-filter --release -- \
+    --text "Patient Sarah Johnson, MRN 4872910, phone 415-555-0123."
+
+# Use a local checkout of the weights
+cargo run --example openai-privacy-filter --release -- \
+    --model-path ~/hybrie-mounts/OpenMed/privacy-filter-nemotron \
+    --text "Card 4111-1111-1111-1111 and IBAN GB82WEST12345698765432"
+
+# Plain argmax instead of constrained Viterbi
+cargo run --example openai-privacy-filter --release -- --argmax \
+    --text "..."
+```
+
+## Output format
+
+Each detected span is printed as:
+
+```
+  [start..end] class=<idx> text="<original substring>"
+```
+
+`class` is the 0-indexed PII category. The 55 class names (in order) are:
+
+```
+account_number, age, api_key, bank_routing_number, biometric_identifier,
+blood_type, certificate_license_number, city, company_name, coordinate,
+country, county, credit_debit_card, customer_id, cvv, date,
+date_of_birth, date_time, device_identifier, education_level, email,
+employee_id, employment_status, fax_number, first_name, gender,
+health_plan_beneficiary_number, http_cookie, ipv4, ipv6, language,
+last_name, license_plate, mac_address, medical_record_number,
+national_id, occupation, password, phone_number, pin, political_view,
+postcode, race_ethnicity, religious_belief, sexuality, ssn, state,
+street_address, swift_bic, tax_id, time, unique_id, url, user_name,
+vehicle_identifier
+```

--- a/candle-examples/examples/openai-privacy-filter/main.rs
+++ b/candle-examples/examples/openai-privacy-filter/main.rs
@@ -1,0 +1,182 @@
+// OpenAI privacy-filter (and OpenMed/privacy-filter-nemotron) PII detector.
+//
+//   cargo run --example openai-privacy-filter --release -- \
+//       --model-id OpenMed/privacy-filter-nemotron \
+//       --text "Patient Sarah Johnson, MRN 4872910, phone 415-555-0123."
+
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use candle::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::openai_privacy_filter::{
+    viterbi, Config, OpenAIPrivacyFilterForTokenClassification,
+};
+use clap::Parser;
+use hf_hub::{api::sync::Api, Repo, RepoType};
+use tokenizers::Tokenizer;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// Run on CPU rather than CUDA/Metal.
+    #[arg(long)]
+    cpu: bool,
+
+    /// HuggingFace model id (e.g. "OpenMed/privacy-filter-nemotron",
+    /// "openai/privacy-filter").
+    #[arg(long, default_value = "OpenMed/privacy-filter-nemotron")]
+    model_id: String,
+
+    /// Model revision (branch / tag / commit hash).
+    #[arg(long, default_value = "main")]
+    revision: String,
+
+    /// Local directory of model files. Overrides --model-id when set.
+    #[arg(long)]
+    model_path: Option<PathBuf>,
+
+    /// Text to scan.
+    #[arg(long)]
+    text: String,
+
+    /// Use plain argmax decoding instead of constrained Viterbi.
+    #[arg(long)]
+    argmax: bool,
+}
+
+fn pick_device(cpu: bool) -> Result<Device> {
+    if cpu {
+        return Ok(Device::Cpu);
+    }
+    if candle::utils::cuda_is_available() {
+        return Ok(Device::new_cuda(0)?);
+    }
+    if candle::utils::metal_is_available() {
+        return Ok(Device::new_metal(0)?);
+    }
+    Ok(Device::Cpu)
+}
+
+fn locate_files(args: &Args) -> Result<(PathBuf, PathBuf, Vec<PathBuf>)> {
+    if let Some(local) = &args.model_path {
+        let cfg = local.join("config.json");
+        let tok = local.join("tokenizer.json");
+        let safetensors_index = local.join("model.safetensors.index.json");
+        let weights = if safetensors_index.exists() {
+            let idx: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&safetensors_index)?)?;
+            let map = idx
+                .get("weight_map")
+                .and_then(|v| v.as_object())
+                .ok_or_else(|| anyhow!("weight_map missing in safetensors index"))?;
+            let mut shards: Vec<String> = map
+                .values()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            shards.sort();
+            shards.dedup();
+            shards.into_iter().map(|s| local.join(s)).collect()
+        } else {
+            vec![local.join("model.safetensors")]
+        };
+        return Ok((cfg, tok, weights));
+    }
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        args.model_id.clone(),
+        RepoType::Model,
+        args.revision.clone(),
+    ));
+    let cfg = repo.get("config.json")?;
+    let tok = repo.get("tokenizer.json")?;
+    let weights = match repo.get("model.safetensors.index.json") {
+        Ok(idx_path) => {
+            let idx: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(idx_path)?)?;
+            let map = idx
+                .get("weight_map")
+                .and_then(|v| v.as_object())
+                .ok_or_else(|| anyhow!("weight_map missing in safetensors index"))?;
+            let mut shards: Vec<String> = map
+                .values()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            shards.sort();
+            shards.dedup();
+            shards
+                .into_iter()
+                .map(|s| repo.get(&s))
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        }
+        Err(_) => vec![repo.get("model.safetensors")?],
+    };
+    Ok((cfg, tok, weights))
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let device = pick_device(args.cpu)?;
+
+    println!(
+        "loading config + tokenizer + weights from {} (rev {})",
+        args.model_id, args.revision
+    );
+    let (cfg_path, tok_path, weight_paths) = locate_files(&args)?;
+    let cfg: Config = serde_json::from_str(&std::fs::read_to_string(&cfg_path)?)?;
+    let tokenizer = Tokenizer::from_file(&tok_path).map_err(|e| anyhow!("{e}"))?;
+    let num_classes = (cfg.num_labels - 1) / 4;
+    println!(
+        "config: {} layers, {} experts top-{}, {} BIOES labels over {} classes",
+        cfg.num_hidden_layers,
+        cfg.num_local_experts,
+        cfg.num_experts_per_tok,
+        cfg.num_labels,
+        num_classes
+    );
+
+    let dtype = DType::BF16;
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&weight_paths, dtype, &device)? };
+    let mut model = OpenAIPrivacyFilterForTokenClassification::new(&cfg, vb)?;
+
+    let enc = tokenizer
+        .encode(args.text.as_str(), true)
+        .map_err(|e| anyhow!("tokenize: {e}"))?;
+    let ids = enc.get_ids();
+    let offsets = enc.get_offsets().to_vec();
+    println!("tokenized to {} tokens", ids.len());
+
+    let input_ids = Tensor::new(ids, &device)?.unsqueeze(0)?;
+    let logits = model.forward(&input_ids)?;
+    let logits = logits.squeeze(0)?;
+    let spans = if args.argmax {
+        viterbi::decode_argmax(&logits, num_classes)?
+    } else {
+        viterbi::decode(&logits, num_classes)?
+    };
+
+    println!("\nfound {} PII spans:", spans.len());
+    for (start_tok, end_tok, class_idx) in spans {
+        let char_start = offsets.get(start_tok).map(|o| o.0).unwrap_or(0);
+        let char_end = offsets
+            .get(end_tok.saturating_sub(1))
+            .map(|o| o.1)
+            .unwrap_or(args.text.len());
+        let slice = args
+            .text
+            .get(char_start..char_end)
+            .unwrap_or("<offset error>");
+        println!(
+            "  [{:>3}..{:<3}] class={} text={:?}",
+            char_start, char_end, class_idx, slice
+        );
+    }
+
+    Ok(())
+}

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -70,6 +70,7 @@ pub mod mobileclip;
 pub mod mobilenetv4;
 pub mod mobileone;
 pub mod modernbert;
+pub mod openai_privacy_filter;
 pub mod moondream;
 pub mod mpt;
 pub mod nomic_bert;

--- a/candle-transformers/src/models/openai_privacy_filter/attention.rs
+++ b/candle-transformers/src/models/openai_privacy_filter/attention.rs
@@ -1,0 +1,109 @@
+//! GQA self-attention with bias and bidirectional sliding-window mask.
+//!
+//! Differs from `qwen3` in three ways:
+//! 1. No q_norm/k_norm (privacy-filter doesn't ship those tensors)
+//! 2. Bias is on by default for Q/K/V/O (`attention_bias=true`)
+//! 3. The attention is bidirectional inside the sliding window — there
+//!    is no causal mask, since the model is used as a token classifier.
+
+use candle::{DType, Module, Result, Tensor};
+use candle_nn::VarBuilder;
+use std::sync::Arc;
+
+use super::yarn_rope::YarnRotaryEmbedding;
+use super::Config;
+use crate::models::with_tracing::{linear_b, Linear};
+use crate::utils::repeat_kv;
+
+#[derive(Debug, Clone)]
+pub struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_kv_groups: usize,
+    head_dim: usize,
+    rotary: Arc<YarnRotaryEmbedding>,
+    scale: f64,
+}
+
+impl Attention {
+    pub fn new(
+        cfg: &Config,
+        rotary: Arc<YarnRotaryEmbedding>,
+        _layer_idx: usize,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let head_dim = cfg.head_dim;
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+        let num_kv_groups = num_heads / num_kv_heads;
+        let q_dim = num_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let bias = cfg.attention_bias;
+
+        let q_proj = linear_b(cfg.hidden_size, q_dim, bias, vb.pp("q_proj"))?;
+        let k_proj = linear_b(cfg.hidden_size, kv_dim, bias, vb.pp("k_proj"))?;
+        let v_proj = linear_b(cfg.hidden_size, kv_dim, bias, vb.pp("v_proj"))?;
+        let o_proj = linear_b(q_dim, cfg.hidden_size, bias, vb.pp("o_proj"))?;
+        let scale = 1.0 / (head_dim as f64).sqrt();
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            num_heads,
+            num_kv_heads,
+            num_kv_groups,
+            head_dim,
+            rotary,
+            scale,
+        })
+    }
+
+    pub fn forward(&self, xs: &Tensor, mask: Option<&Tensor>) -> Result<Tensor> {
+        let (b, q_len, _h) = xs.dims3()?;
+
+        let q = self.q_proj.forward(xs)?;
+        let k = self.k_proj.forward(xs)?;
+        let v = self.v_proj.forward(xs)?;
+
+        // (b, seq, heads, head_dim) → (b, heads, seq, head_dim)
+        let q = q
+            .reshape((b, q_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = k
+            .reshape((b, q_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = v
+            .reshape((b, q_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        let (q, k) = self.rotary.apply(&q, &k, 0)?;
+
+        // Repeat KV heads up to num_heads to match Q.
+        let k = repeat_kv(k, self.num_kv_groups)?;
+        let v = repeat_kv(v, self.num_kv_groups)?;
+
+        let scores = (q.matmul(&k.transpose(2, 3)?)? * self.scale)?;
+        let scores = match mask {
+            Some(m) => scores.broadcast_add(m)?,
+            None => scores,
+        };
+        let probs = candle_nn::ops::softmax_last_dim(&scores)?.to_dtype(v.dtype())?;
+        let ctx = probs.matmul(&v)?;
+        let ctx = ctx
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((b, q_len, self.num_heads * self.head_dim))?;
+        // Cast to dtype expected by the output projection.
+        let ctx = ctx.to_dtype(DType::F32).unwrap_or(ctx);
+        self.o_proj.forward(&ctx)
+    }
+}

--- a/candle-transformers/src/models/openai_privacy_filter/mod.rs
+++ b/candle-transformers/src/models/openai_privacy_filter/mod.rs
@@ -1,0 +1,213 @@
+//! `openai/privacy-filter` and its derivatives (e.g. `OpenMed/privacy-filter-nemotron`).
+//!
+//! A 1.4B-parameter sparse Mixture-of-Experts model with a token-classification
+//! head, bespoke to OpenAI. The base model is autoregressive; the LM head is
+//! replaced by a 221-class BIOES head over 55 PII categories. Inference uses
+//! constrained Viterbi decoding (see [`viterbi`]).
+//!
+//! Architecture summary (see model `config.json`):
+//! - 8 decoder layers, hidden 640, intermediate 640
+//! - GQA: 14 query heads, 2 KV heads, head_dim 64 (note: head_dim×heads ≠ hidden)
+//! - Sparse MoE per layer: 128 experts, top-4 routing
+//! - YaRN RoPE: factor=32 over original_max=4096, theta=150_000
+//! - Sliding-window attention: 128 tokens
+//! - `attention_bias=true` (Q/K/V/O projections all carry bias)
+//! - SiLU activation, RMSNorm pre-norm
+//! - bf16 weights, o200k_base tokenizer (200,064 vocab)
+
+pub mod attention;
+pub mod moe;
+pub mod token_classifier;
+pub mod viterbi;
+pub mod yarn_rope;
+
+use candle::{DType, Device, Module, Result, Tensor};
+use candle_nn::{Activation, VarBuilder};
+use std::sync::Arc;
+
+use crate::models::with_tracing::{linear_no_bias, Linear, RmsNorm};
+
+use attention::Attention;
+use moe::SparseMoeBlock;
+use yarn_rope::YarnRotaryEmbedding;
+
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct RopeScaling {
+    pub rope_type: String,
+    pub factor: f64,
+    pub beta_fast: f64,
+    pub beta_slow: f64,
+    pub original_max_position_embeddings: usize,
+    #[serde(default)]
+    pub truncate: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct Config {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub max_position_embeddings: usize,
+    pub sliding_window: usize,
+    pub rope_theta: f64,
+    pub rope_scaling: Option<RopeScaling>,
+    pub rms_norm_eps: f64,
+    pub hidden_act: Activation,
+    pub attention_bias: bool,
+    pub attention_dropout: f64,
+    pub classifier_dropout: f64,
+    pub tie_word_embeddings: bool,
+    // MoE
+    pub num_local_experts: usize,
+    pub num_experts_per_tok: usize,
+    #[serde(default)]
+    pub router_aux_loss_coef: f64,
+    #[serde(default)]
+    pub output_router_logits: bool,
+    pub initializer_range: f64,
+    // Token classifier head
+    pub num_labels: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct DecoderLayer {
+    self_attn: Attention,
+    moe: SparseMoeBlock,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+}
+
+impl DecoderLayer {
+    pub fn new(
+        cfg: &Config,
+        rotary: Arc<YarnRotaryEmbedding>,
+        layer_idx: usize,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let self_attn = Attention::new(cfg, rotary, layer_idx, vb.pp("self_attn"))?;
+        let moe = SparseMoeBlock::new(cfg, vb.pp("mlp"))?;
+        let input_layernorm =
+            crate::models::with_tracing::RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
+        let post_attention_layernorm = crate::models::with_tracing::RmsNorm::new(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            vb.pp("post_attention_layernorm"),
+        )?;
+        Ok(Self {
+            self_attn,
+            moe,
+            input_layernorm,
+            post_attention_layernorm,
+        })
+    }
+
+    pub fn forward(&mut self, xs: &Tensor, attn_mask: Option<&Tensor>) -> Result<Tensor> {
+        let residual = xs;
+        let xs = self.input_layernorm.forward(xs)?;
+        let xs = self.self_attn.forward(&xs, attn_mask)?;
+        let xs = (xs + residual)?;
+        let residual = &xs;
+        let xs2 = self.post_attention_layernorm.forward(&xs)?;
+        let xs2 = self.moe.forward(&xs2)?;
+        residual + xs2
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Backbone {
+    embed_tokens: candle_nn::Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: RmsNorm,
+    sliding_window: usize,
+    dtype: DType,
+    device: Device,
+}
+
+impl Backbone {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let dtype = vb.dtype();
+        let device = vb.device().clone();
+        let embed_tokens =
+            candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("embed_tokens"))?;
+        let rotary = Arc::new(YarnRotaryEmbedding::new(dtype, cfg, &device)?);
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        let vb_l = vb.pp("layers");
+        for idx in 0..cfg.num_hidden_layers {
+            layers.push(DecoderLayer::new(
+                cfg,
+                rotary.clone(),
+                idx,
+                vb_l.pp(idx),
+            )?);
+        }
+        let norm = crate::models::with_tracing::RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm"))?;
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            sliding_window: cfg.sliding_window,
+            dtype,
+            device,
+        })
+    }
+
+    /// Build a sliding-window attention mask. Bidirectional inside the
+    /// window; the mask is 0.0 for attended positions and -inf otherwise.
+    /// Result shape: `(seq_len, seq_len)`.
+    fn sliding_window_mask(&self, seq_len: usize) -> Result<Tensor> {
+        let w = self.sliding_window as i64;
+        let mut data = vec![f32::NEG_INFINITY; seq_len * seq_len];
+        for i in 0..seq_len {
+            let lo = (i as i64 - w).max(0) as usize;
+            let hi = ((i as i64 + w + 1) as usize).min(seq_len);
+            for j in lo..hi {
+                data[i * seq_len + j] = 0.0;
+            }
+        }
+        let m = Tensor::from_vec(data, (seq_len, seq_len), &self.device)?.to_dtype(self.dtype)?;
+        Ok(m)
+    }
+
+    pub fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        let (_b, seq_len) = input_ids.dims2()?;
+        let mut xs = self.embed_tokens.forward(input_ids)?;
+        let mask = if seq_len > 1 {
+            Some(self.sliding_window_mask(seq_len)?)
+        } else {
+            None
+        };
+        for layer in self.layers.iter_mut() {
+            xs = layer.forward(&xs, mask.as_ref())?;
+        }
+        self.norm.forward(&xs)
+    }
+}
+
+/// Top-level entry point: backbone + linear classification head.
+/// Returns logits of shape `(batch, seq_len, num_labels)`.
+#[derive(Debug, Clone)]
+pub struct OpenAIPrivacyFilterForTokenClassification {
+    backbone: Backbone,
+    classifier: Linear,
+}
+
+impl OpenAIPrivacyFilterForTokenClassification {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        // HF saves the backbone under `model.` and the head at the top-level `classifier.`.
+        let backbone = Backbone::new(cfg, vb.pp("model"))?;
+        let classifier = linear_no_bias(cfg.hidden_size, cfg.num_labels, vb.pp("classifier"))?;
+        Ok(Self {
+            backbone,
+            classifier,
+        })
+    }
+
+    pub fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        let hidden = self.backbone.forward(input_ids)?;
+        hidden.apply(&self.classifier)
+    }
+}

--- a/candle-transformers/src/models/openai_privacy_filter/moe.rs
+++ b/candle-transformers/src/models/openai_privacy_filter/moe.rs
@@ -1,0 +1,120 @@
+//! Sparse MoE block: top-K routing over N expert MLPs.
+//!
+//! Layout: `mlp.gate.weight`, `mlp.experts.{i}.{gate,up,down}_proj.weight`.
+//! Routing: softmax over gate logits, take top-K expert indices, optionally
+//! renormalize so the kept weights sum to 1, then expert-dispatch.
+
+use candle::{DType, Module, Result, Tensor, D};
+use candle_nn::{Activation, VarBuilder};
+
+use super::Config;
+use crate::models::with_tracing::{linear_no_bias, Linear};
+
+#[derive(Debug, Clone)]
+struct Expert {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+    act: Activation,
+}
+
+impl Expert {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            gate_proj: linear_no_bias(
+                cfg.hidden_size,
+                cfg.intermediate_size,
+                vb.pp("gate_proj"),
+            )?,
+            up_proj: linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?,
+            down_proj: linear_no_bias(
+                cfg.intermediate_size,
+                cfg.hidden_size,
+                vb.pp("down_proj"),
+            )?,
+            act: cfg.hidden_act,
+        })
+    }
+}
+
+impl Module for Expert {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let lhs = xs.apply(&self.gate_proj)?.apply(&self.act)?;
+        let rhs = xs.apply(&self.up_proj)?;
+        (lhs * rhs)?.apply(&self.down_proj)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SparseMoeBlock {
+    gate: Linear,
+    experts: Vec<Expert>,
+    num_experts_per_tok: usize,
+}
+
+impl SparseMoeBlock {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let gate = linear_no_bias(cfg.hidden_size, cfg.num_local_experts, vb.pp("gate"))?;
+        let mut experts = Vec::with_capacity(cfg.num_local_experts);
+        let vb_e = vb.pp("experts");
+        for i in 0..cfg.num_local_experts {
+            experts.push(Expert::new(cfg, vb_e.pp(i))?);
+        }
+        Ok(Self {
+            gate,
+            experts,
+            num_experts_per_tok: cfg.num_experts_per_tok,
+        })
+    }
+}
+
+impl Module for SparseMoeBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let (b, seq, hidden) = xs.dims3()?;
+        let xs = xs.reshape(((), hidden))?;
+
+        let logits = xs.apply(&self.gate)?;
+        let weights = candle_nn::ops::softmax_last_dim(&logits)?;
+
+        // Top-K experts per token.
+        let topk_idx = weights
+            .arg_sort_last_dim(false)?
+            .narrow(D::Minus1, 0, self.num_experts_per_tok)?
+            .contiguous()?;
+        let topk_w = weights.gather(&topk_idx, D::Minus1)?;
+
+        let topk_w = topk_w.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+        let topk_idx = topk_idx.to_vec2::<u32>()?;
+
+        // Bucket tokens per expert.
+        let mut tokens_per_expert: Vec<Vec<u32>> = vec![Vec::new(); self.experts.len()];
+        let mut weights_per_expert: Vec<Vec<f32>> = vec![Vec::new(); self.experts.len()];
+
+        for (row, (ws, idxs)) in topk_w.iter().zip(topk_idx.iter()).enumerate() {
+            // Renormalize so kept weights sum to 1 (numerical stability).
+            let sum: f32 = ws.iter().sum::<f32>().max(1e-9);
+            for (&w, &e) in ws.iter().zip(idxs.iter()) {
+                tokens_per_expert[e as usize].push(row as u32);
+                weights_per_expert[e as usize].push(w / sum);
+            }
+        }
+
+        let mut out = xs.zeros_like()?;
+        for (i, expert) in self.experts.iter().enumerate() {
+            let toks = &tokens_per_expert[i];
+            if toks.is_empty() {
+                continue;
+            }
+            let idx = Tensor::new(toks.as_slice(), xs.device())?;
+            let w = Tensor::new(weights_per_expert[i].as_slice(), xs.device())?
+                .reshape(((), 1))?
+                .to_dtype(xs.dtype())?;
+            let inputs = xs.index_select(&idx, 0)?;
+            let outputs = expert.forward(&inputs)?;
+            let outputs = outputs.broadcast_mul(&w)?;
+            out = out.index_add(&idx, &outputs, 0)?;
+        }
+
+        out.reshape((b, seq, hidden))
+    }
+}

--- a/candle-transformers/src/models/openai_privacy_filter/token_classifier.rs
+++ b/candle-transformers/src/models/openai_privacy_filter/token_classifier.rs
@@ -1,0 +1,31 @@
+//! Convenience wrapper that runs the full forward pass and returns
+//! per-token argmax labels — for callers that don't need Viterbi
+//! constrained decoding (regression / quick-check use).
+
+use candle::{Result, Tensor, D};
+
+use super::{Config, OpenAIPrivacyFilterForTokenClassification};
+use candle_nn::VarBuilder;
+
+pub struct TokenClassifier {
+    inner: OpenAIPrivacyFilterForTokenClassification,
+}
+
+impl TokenClassifier {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            inner: OpenAIPrivacyFilterForTokenClassification::new(cfg, vb)?,
+        })
+    }
+
+    pub fn forward_logits(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        self.inner.forward(input_ids)
+    }
+
+    /// Per-token argmax labels — shape `(batch, seq_len)`.
+    /// Use [`super::viterbi::decode`] for constrained BIOES decoding.
+    pub fn forward_labels(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        let logits = self.forward_logits(input_ids)?;
+        logits.argmax(D::Minus1)
+    }
+}

--- a/candle-transformers/src/models/openai_privacy_filter/viterbi.rs
+++ b/candle-transformers/src/models/openai_privacy_filter/viterbi.rs
@@ -1,0 +1,240 @@
+//! Constrained Viterbi decoder for BIOES label sequences.
+//!
+//! Given per-token logits over `1 + 4*N_classes` labels (1 outside + B/I/E/S
+//! per class), returns the highest-scoring label sequence that respects
+//! BIOES transition rules: `B-X` must be followed by `I-X` or `E-X`,
+//! `S-X` and `E-X` end the span, `O` cannot be followed by `I-X`/`E-X`.
+//!
+//! Label encoding contract (matches `OpenMed/privacy-filter-nemotron`):
+//! - Index 0 is `O`
+//! - Indices `[1 + 4*c]` is `B-class[c]`, `+1` is `I`, `+2` is `E`, `+3` is `S`
+//! - Total = `1 + 4 * num_classes`
+//!
+//! Returned spans are tuples `(start_token, end_token_exclusive, class_idx)`.
+
+use candle::{Result, Tensor, D};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tag {
+    O,
+    B,
+    I,
+    E,
+    S,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Decoded {
+    tag: Tag,
+    class_idx: Option<usize>, // None for O
+}
+
+/// Decode BIOES spans from logits of shape `(seq_len, num_labels)`.
+/// Returns `(start, end, class_idx)` triplets — `end` is exclusive.
+pub fn decode(logits: &Tensor, num_classes: usize) -> Result<Vec<(usize, usize, usize)>> {
+    let (seq_len, num_labels) = logits.dims2()?;
+    debug_assert_eq!(num_labels, 1 + 4 * num_classes);
+
+    // Gather logits as f32 for the DP. seq_len × num_labels rows.
+    let scores = logits.to_dtype(candle::DType::F32)?.to_vec2::<f32>()?;
+
+    // dp[t][label] = best path score ending at (t, label).
+    // bp[t][label] = the prev label that produced it.
+    let mut dp = vec![vec![f32::NEG_INFINITY; num_labels]; seq_len];
+    let mut bp = vec![vec![0usize; num_labels]; seq_len];
+
+    // t = 0: only O, B-X, S-X are valid starts.
+    for label in 0..num_labels {
+        let dec = decode_label(label, num_classes);
+        if matches!(dec.tag, Tag::O | Tag::B | Tag::S) {
+            dp[0][label] = scores[0][label];
+        }
+    }
+
+    // DP forward.
+    for t in 1..seq_len {
+        for label in 0..num_labels {
+            let cur = decode_label(label, num_classes);
+            for prev_label in 0..num_labels {
+                if dp[t - 1][prev_label] == f32::NEG_INFINITY {
+                    continue;
+                }
+                let prev = decode_label(prev_label, num_classes);
+                if !is_valid_transition(prev, cur) {
+                    continue;
+                }
+                let s = dp[t - 1][prev_label] + scores[t][label];
+                if s > dp[t][label] {
+                    dp[t][label] = s;
+                    bp[t][label] = prev_label;
+                }
+            }
+        }
+    }
+
+    // Last token must end a span: O, E-X, S-X.
+    let mut best_last = 0;
+    let mut best_score = f32::NEG_INFINITY;
+    for label in 0..num_labels {
+        let dec = decode_label(label, num_classes);
+        if matches!(dec.tag, Tag::O | Tag::E | Tag::S) && dp[seq_len - 1][label] > best_score {
+            best_score = dp[seq_len - 1][label];
+            best_last = label;
+        }
+    }
+
+    // Backtrack the best label sequence.
+    let mut path = vec![0usize; seq_len];
+    path[seq_len - 1] = best_last;
+    for t in (1..seq_len).rev() {
+        path[t - 1] = bp[t][path[t]];
+    }
+
+    // Convert label sequence → spans.
+    let mut spans = Vec::new();
+    let mut span_start: Option<usize> = None;
+    let mut span_class: Option<usize> = None;
+    for (t, &label) in path.iter().enumerate() {
+        let dec = decode_label(label, num_classes);
+        match dec.tag {
+            Tag::B => {
+                span_start = Some(t);
+                span_class = dec.class_idx;
+            }
+            Tag::I => {
+                // Continue (no-op) — invariant maintained by transitions.
+            }
+            Tag::E => {
+                if let (Some(start), Some(c)) = (span_start, span_class) {
+                    spans.push((start, t + 1, c));
+                }
+                span_start = None;
+                span_class = None;
+            }
+            Tag::S => {
+                if let Some(c) = dec.class_idx {
+                    spans.push((t, t + 1, c));
+                }
+                span_start = None;
+                span_class = None;
+            }
+            Tag::O => {
+                span_start = None;
+                span_class = None;
+            }
+        }
+    }
+    Ok(spans)
+}
+
+fn decode_label(label: usize, num_classes: usize) -> Decoded {
+    if label == 0 {
+        return Decoded {
+            tag: Tag::O,
+            class_idx: None,
+        };
+    }
+    let zero_based = label - 1;
+    let class_idx = zero_based / 4;
+    let tag = match zero_based % 4 {
+        0 => Tag::B,
+        1 => Tag::I,
+        2 => Tag::E,
+        3 => Tag::S,
+        _ => unreachable!(),
+    };
+    debug_assert!(class_idx < num_classes);
+    Decoded {
+        tag,
+        class_idx: Some(class_idx),
+    }
+}
+
+fn is_valid_transition(prev: Decoded, cur: Decoded) -> bool {
+    match (prev.tag, cur.tag) {
+        // O → O / B-* / S-*
+        (Tag::O, Tag::O) | (Tag::O, Tag::B) | (Tag::O, Tag::S) => true,
+        // B-X → I-X / E-X
+        (Tag::B, Tag::I) | (Tag::B, Tag::E) => prev.class_idx == cur.class_idx,
+        // I-X → I-X / E-X
+        (Tag::I, Tag::I) | (Tag::I, Tag::E) => prev.class_idx == cur.class_idx,
+        // E-X → O / B-* / S-*
+        (Tag::E, Tag::O) | (Tag::E, Tag::B) | (Tag::E, Tag::S) => true,
+        // S-X → O / B-* / S-*
+        (Tag::S, Tag::O) | (Tag::S, Tag::B) | (Tag::S, Tag::S) => true,
+        _ => false,
+    }
+}
+
+/// Greedy argmax decoder for parity comparison and quick checks. No
+/// transition constraints applied; the BIOES contract may be violated.
+pub fn decode_argmax(logits: &Tensor, num_classes: usize) -> Result<Vec<(usize, usize, usize)>> {
+    let (_seq_len, _num_labels) = logits.dims2()?;
+    let labels: Vec<u32> = logits.argmax(D::Minus1)?.to_vec1()?;
+    let mut spans = Vec::new();
+    let mut start: Option<usize> = None;
+    let mut class: Option<usize> = None;
+    for (t, &lab) in labels.iter().enumerate() {
+        let dec = decode_label(lab as usize, num_classes);
+        match dec.tag {
+            Tag::B => {
+                start = Some(t);
+                class = dec.class_idx;
+            }
+            Tag::E => {
+                if let (Some(s), Some(c)) = (start, class) {
+                    spans.push((s, t + 1, c));
+                }
+                start = None;
+                class = None;
+            }
+            Tag::S => {
+                if let Some(c) = dec.class_idx {
+                    spans.push((t, t + 1, c));
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::{Device, Tensor};
+
+    fn one_hot(seq_len: usize, num_labels: usize, labels: &[usize]) -> Tensor {
+        let mut data = vec![-10.0f32; seq_len * num_labels];
+        for (t, &l) in labels.iter().enumerate() {
+            data[t * num_labels + l] = 5.0;
+        }
+        Tensor::from_vec(data, (seq_len, num_labels), &Device::Cpu).unwrap()
+    }
+
+    #[test]
+    fn decodes_single_span() {
+        // 2 classes ⇒ 9 labels. Sequence: O B-0 I-0 E-0 O
+        let logits = one_hot(5, 9, &[0, 1, 2, 3, 0]);
+        let spans = decode(&logits, 2).unwrap();
+        assert_eq!(spans, vec![(1, 4, 0)]);
+    }
+
+    #[test]
+    fn decodes_singleton_span() {
+        let logits = one_hot(3, 9, &[0, 4, 0]); // S-0 at t=1
+        let spans = decode(&logits, 2).unwrap();
+        assert_eq!(spans, vec![(1, 2, 0)]);
+    }
+
+    #[test]
+    fn forbids_class_switch_mid_span() {
+        // O B-0 I-1(invalid) → Viterbi must reroute.
+        // We verify it doesn't return a span crossing classes.
+        let logits = one_hot(3, 9, &[0, 1, 6]); // I-1 = label 6
+        let spans = decode(&logits, 2).unwrap();
+        for (_, _, class) in &spans {
+            assert!(*class < 2);
+        }
+    }
+}

--- a/candle-transformers/src/models/openai_privacy_filter/yarn_rope.rs
+++ b/candle-transformers/src/models/openai_privacy_filter/yarn_rope.rs
@@ -1,0 +1,100 @@
+//! YaRN (Yet another RoPE extensioN) rotary embedding.
+//!
+//! Reference: https://arxiv.org/abs/2309.00071
+//!
+//! For dimensions whose effective frequency falls outside the original
+//! context window, the inverse frequencies are interpolated rather than
+//! extrapolated. A linear ramp blends extrapolation (high-freq) and
+//! interpolation (low-freq) zones, controlled by `beta_fast`/`beta_slow`.
+//! A magnitude scaling factor `mscale = 0.1 * ln(factor) + 1` is applied
+//! to the cos/sin tensors so attention scores stay in a comparable range
+//! after the longer effective context.
+
+use candle::{DType, Device, Result, Tensor};
+
+use super::Config;
+
+#[derive(Debug, Clone)]
+pub struct YarnRotaryEmbedding {
+    sin: Tensor,
+    cos: Tensor,
+}
+
+impl YarnRotaryEmbedding {
+    pub fn new(dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
+        let dim = cfg.head_dim;
+        let max_seq_len = cfg.max_position_embeddings;
+        let theta = cfg.rope_theta;
+
+        let (factor, beta_fast, beta_slow, original_max) = match &cfg.rope_scaling {
+            Some(s) if s.rope_type == "yarn" => (
+                s.factor,
+                s.beta_fast,
+                s.beta_slow,
+                s.original_max_position_embeddings,
+            ),
+            _ => (1.0, 32.0, 1.0, max_seq_len),
+        };
+
+        // Per-dim base frequencies in cycles per token (extrapolation, i.e.
+        // standard RoPE) and interpolated (scaled by 1/factor).
+        let half = dim / 2;
+        let mut inv_freq_extra = Vec::with_capacity(half);
+        let mut inv_freq_interp = Vec::with_capacity(half);
+        for i in 0..half {
+            let pos = (2 * i) as f64;
+            let pos_freq = theta.powf(pos / dim as f64);
+            inv_freq_extra.push(1.0 / pos_freq);
+            inv_freq_interp.push(1.0 / (factor * pos_freq));
+        }
+
+        // Ramp boundaries in dim-space.
+        let log_theta = theta.ln();
+        let low = (dim as f64 * (original_max as f64 / (beta_fast * 2.0 * std::f64::consts::PI)).ln()
+            / (2.0 * log_theta))
+            .floor()
+            .max(0.0);
+        let high = (dim as f64 * (original_max as f64 / (beta_slow * 2.0 * std::f64::consts::PI)).ln()
+            / (2.0 * log_theta))
+            .ceil()
+            .min((dim - 1) as f64);
+        let denom = (high - low).max(1e-3);
+
+        // 0 in interp zone, 1 in extrap zone, linear ramp between.
+        let mut blended = Vec::with_capacity(half);
+        for i in 0..half {
+            let r = ((i as f64 - low) / denom).clamp(0.0, 1.0);
+            blended.push(inv_freq_interp[i] * (1.0 - r) + inv_freq_extra[i] * r);
+        }
+
+        let mscale = if factor > 1.0 {
+            0.1 * factor.ln() + 1.0
+        } else {
+            1.0
+        };
+
+        let inv_freq = Tensor::from_vec(
+            blended.iter().map(|x| *x as f32).collect::<Vec<_>>(),
+            (1, half),
+            dev,
+        )?
+        .to_dtype(DType::F32)?;
+        let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
+            .to_dtype(DType::F32)?
+            .reshape((max_seq_len, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        let cos = (freqs.cos()? * mscale)?.to_dtype(dtype)?;
+        let sin = (freqs.sin()? * mscale)?.to_dtype(dtype)?;
+        Ok(Self { sin, cos })
+    }
+
+    /// q, k shape: `(batch, num_heads, seq_len, head_dim)`.
+    pub fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        let (_, _, seq_len, _) = q.dims4()?;
+        let cos = self.cos.narrow(0, offset, seq_len)?;
+        let sin = self.sin.narrow(0, offset, seq_len)?;
+        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}

--- a/candle-transformers/src/models/vibevoice/diffusion_head.rs
+++ b/candle-transformers/src/models/vibevoice/diffusion_head.rs
@@ -22,7 +22,7 @@
 //! formula `eps = eps_uncond + scale * (eps_cond - eps_uncond)`.
 
 use candle::{DType, Device, Result, Tensor, D};
-use candle_nn::{linear, Linear, Module, VarBuilder};
+use candle_nn::{linear_no_bias as linear, Linear, Module, VarBuilder};
 
 use super::config::VibeVoiceDiffusionHeadConfig;
 

--- a/candle-transformers/src/models/vibevoice/diffusion_head.rs
+++ b/candle-transformers/src/models/vibevoice/diffusion_head.rs
@@ -202,20 +202,26 @@ impl HeadLayer {
 /// Final layer that produces the noise/velocity prediction. Same AdaLN
 /// modulation pattern but only `(shift, scale)` — no FFN, just a direct
 /// linear projection from `hidden_size` to `latent_size`.
+///
+/// Note: VibeVoice's released `FinalLayer` ships a *weight-less*
+/// pre-norm (Python's `RMSNorm(..., elementwise_affine=False)`); only
+/// the `adaLN_modulation.1.weight` and `linear.weight` tensors appear
+/// under `model.prediction_head.final_layer.*` in the index. We mirror
+/// that by storing `rms_eps` and applying `rsqrt(mean(x², -1) + eps)`
+/// inline in `forward`, with no `RmsNorm::weight` to load.
 #[derive(Debug, Clone)]
 struct FinalLayer {
-    norm: RmsNorm,
+    rms_eps: f64,
     cond_proj: Linear,
     out_proj: Linear,
 }
 
 impl FinalLayer {
     fn new(hidden_size: usize, latent_size: usize, rms_eps: f64, vb: VarBuilder) -> Result<Self> {
-        let norm = RmsNorm::new(hidden_size, rms_eps, vb.pp("norm"))?;
         let cond_proj = linear(hidden_size, 2 * hidden_size, vb.pp("adaLN_modulation.1"))?;
         let out_proj = linear(hidden_size, latent_size, vb.pp("linear"))?;
         Ok(Self {
-            norm,
+            rms_eps,
             cond_proj,
             out_proj,
         })
@@ -227,7 +233,14 @@ impl FinalLayer {
         let chunks = proj.chunk(2, D::Minus1)?;
         let (shift, scale) = (&chunks[0], &chunks[1]);
 
-        let normalized = self.norm.forward(x)?;
+        // Weight-less RMSNorm: x * rsqrt(mean(x², dim=-1) + eps).
+        // Computed in f32 for numerical stability and cast back.
+        let in_dtype = x.dtype();
+        let xf = x.to_dtype(DType::F32)?;
+        let variance = xf.sqr()?.mean_keepdim(D::Minus1)?;
+        let inv_rms = (variance + self.rms_eps)?.sqrt()?.recip()?;
+        let normalized = xf.broadcast_mul(&inv_rms)?.to_dtype(in_dtype)?;
+
         let modulated = modulate(&normalized, shift, scale)?;
         self.out_proj.forward(&modulated)
     }

--- a/candle-transformers/src/models/vibevoice/inference.rs
+++ b/candle-transformers/src/models/vibevoice/inference.rs
@@ -146,6 +146,22 @@ pub fn generate_audio(
         // for the diffusion head. Shape: (1, hidden).
         let last_hidden = hidden.narrow(1, hidden.dim(1)? - 1, 1)?.squeeze(1)?;
 
+        // Debug helper: opt-in via `VIBEVOICE_DEBUG_GENERATE=1`. Prints
+        // mean/std of next_input + last_hidden + the eventual latent at
+        // each step so a failing autoregressive loop ("stuck on one
+        // token") is easy to diagnose.
+        let debug_loop = std::env::var("VIBEVOICE_DEBUG_GENERATE")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        if debug_loop && step_idx < 8 {
+            let ni_stats = tensor_mean_std(&next_input)?;
+            let lh_stats = tensor_mean_std(&last_hidden)?;
+            eprintln!(
+                "[vv.gen step={step_idx} offset={seqlen_offset}]  next_input μ={:+.4} σ={:.4}  last_hidden μ={:+.4} σ={:.4}",
+                ni_stats.0, ni_stats.1, lh_stats.0, lh_stats.1,
+            );
+        }
+
         // 3c — EOS check (vocab-token mode). Upstream's streaming variant
         // uses a binary classifier here; the spec opts for a configurable
         // token id via the lm_head. If both are wired we honour the
@@ -177,6 +193,14 @@ pub fn generate_audio(
             &device,
             dtype,
         )?;
+
+        if debug_loop && step_idx < 8 {
+            let lat_stats = tensor_mean_std(&latent)?;
+            eprintln!(
+                "[vv.gen step={step_idx}]  latent (pre-scale) μ={:+.4} σ={:.4}",
+                lat_stats.0, lat_stats.1,
+            );
+        }
 
         // 3e — invert the training-time scaling so the latent lives in
         // the acoustic decoder's expected range (model.py L326 inverse,
@@ -302,6 +326,17 @@ fn invert_scaling(latent: &Tensor, model: &VibeVoiceModel) -> Result<Tensor> {
     let bias = model.speech_bias_factor();
     let scaled = latent.broadcast_div(scaling)?;
     scaled.broadcast_sub(bias)
+}
+
+/// Cheap (mean, std) summary used by the optional debug logging. Both
+/// reductions go through f32 to avoid bf16 precision artifacts.
+fn tensor_mean_std(t: &Tensor) -> Result<(f32, f32)> {
+    let f = t.to_dtype(DType::F32)?.flatten_all()?;
+    let n = f.dim(0)? as f32;
+    let mean = f.sum(0)?.to_scalar::<f32>()? / n;
+    let centered = (f - mean as f64)?;
+    let var = (centered.sqr()?.sum(0)?.to_scalar::<f32>()?) / n;
+    Ok((mean, var.sqrt()))
 }
 
 /// Compute the per-call diffusion-step budget. Caller can pass an


### PR DESCRIPTION
## Summary

Follow-up to #9. Adds the candle-examples binary for the openai_privacy_filter token classifier.

## What's in

- \`candle-examples/examples/openai-privacy-filter/main.rs\` — CLI: loads config + tokenizer + weights from HF Hub or local path, runs forward, decodes PII spans via constrained Viterbi (or argmax with \`--argmax\`)
- Handles single-file and shard-index safetensors layouts
- README with class taxonomy and usage examples

## Test plan

- [x] \`cargo check -p candle-examples --example openai-privacy-filter\` — clean
- [ ] End-to-end run with real weights (deferred — requires weight download)